### PR TITLE
findByIdをラムダで修正

### DIFF
--- a/crudapi/src/main/java/com/yuuki/crudapi/controller/EmployController.java
+++ b/crudapi/src/main/java/com/yuuki/crudapi/controller/EmployController.java
@@ -26,12 +26,16 @@ public class EmployController {
         this.employeeService = employeeService;
     }
 
-    // 全ての従業員を取得するメソッド
+    // 全ての従業員を取得，または特定の部署に所属する従業員を取得するメソッド
     @GetMapping("/employees")
-    public List<EmployeeResponse> employees() {
-        List<Employee> employees = employeeService.findAll();
-        List<EmployeeResponse> employeeResponses = employees.stream().map(EmployeeResponse::new).toList();
-        return employeeResponses;
+    public List<EmployeeResponse> getEmployees(@RequestParam(value = "department",required = false)String department) {
+        List<Employee> employees;
+        if(department ==null || department.isEmpty()){
+            employees =employeeService.findAll();
+        }else {
+            employees=employeeService.findByDepartment(department);
+        }
+        return employees.stream().map(EmployeeResponse::new).toList();
     }
 
     // 特定のIDの従業員を取得するメソッド
@@ -40,11 +44,6 @@ public class EmployController {
         return employeeService.findById(id);
     }
 
-    // 特定の部署の従業員を取得するメソッド
-    @GetMapping("/employees/department")
-    public List<Employee> getEmployeeByDepartment(@RequestParam(value = "name", required = false) String department) {
-        return employeeService.findByDepartment(department);
-    }
 
     // ResourceNotFoundException がスローされた場合のハンドラ
     @ExceptionHandler(value = ResourceNotFoundException.class)

--- a/crudapi/src/main/java/com/yuuki/crudapi/service/EmployeeServiceImpl.java
+++ b/crudapi/src/main/java/com/yuuki/crudapi/service/EmployeeServiceImpl.java
@@ -27,12 +27,7 @@ public class EmployeeServiceImpl implements EmployeeService {
     // 特定のIDの従業員を取得するメソッド
     @Override
     public Employee findById(int id) {
-        Optional<Employee> employee = this.employeeMapper.findById(id);
-        if (employee.isPresent()) {
-            return employee.get();
-        } else {
-            throw new ResourceNotFoundException("resource not found");
-        }
+        return this.employeeMapper.findById(id).orElseThrow(()->new ResourceNotFoundException("resource not found"));
     }
 
     // 特定の部署の従業員を取得するメソッド


### PR DESCRIPTION
コードのレビューをお願いいたします．

変更内容
- 以下コードの簡略化
EmployeeServiceImplのfindByIdをラムダを用いて簡略化した.
----
    @Override
    public Employee findById(int id) {
        Optional<Employee> employee = this.employeeMapper.findById(id);
        if (employee.isPresent()) {
            return employee.get();
        } else {
            throw new ResourceNotFoundException("resource not found");
        }
    }
  -----
- **employees/department**を**employees**に統合 
if文を用いてemployeesメソッドとgetEmployeeByDepartmentメソッドを統合した.

- departmentのクエリパラメータがfalseになっている問題
クエリパラメータが存在しない場合は，従業員全員の情報を返すように変更した．
